### PR TITLE
実装

### DIFF
--- a/Assets/Scripts/Main/Block/Block.cs
+++ b/Assets/Scripts/Main/Block/Block.cs
@@ -1,16 +1,36 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Main.Rule;
 
 namespace Main.Block
 {
-    public class Block : IBlock
+    public class Block : MonoBehaviour,IBlock
     {
         [SerializeField]private int blockId;
+        private int[] GridLocation = new int[3];
         public int GetBlockId()
         {
             return blockId;
         }
+
+        void OnCollisionEnter(Collision collision)
+        {
+            if (collision.gameObject.tag == "PlacementDetermination")
+            {
+                collision.gameObject.GetComponent<PlacementDetermination>().PlacementBlock(blockId);
+                GridLocation = collision.gameObject.GetComponent<PlacementDetermination>().GetGridLocation();
+                this.GetComponent<Collider>().enabled = false;
+                //きれいに配置しなおす
+                Relocation(GridLocation);
+            }
+        }
+
+        public void Relocation(int[] GridLocation)
+        {
+            this.transform.position = new Vector3(GridLocation[0], GridLocation[1], GridLocation[2]);
+        }
+
     }
 }
 

--- a/Assets/Scripts/Main/ProcessSystem/ProcessSystem.cs
+++ b/Assets/Scripts/Main/ProcessSystem/ProcessSystem.cs
@@ -1,14 +1,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using Main.RuleSystem;
+using Main.Rule;
 
 namespace Main.ProcessSystem
 {
     public class ProcessSystem : MonoBehaviour
     {
         private Timer timer = default;
-        private Main.RuleSystem.RuleSystem ruleSystem = default;
+        private RuleSystem ruleSystem = default;
         private ProcessState processState = ProcessState.Initialize;
         public enum ProcessState
         {
@@ -53,7 +53,7 @@ namespace Main.ProcessSystem
         private void Initialize()
         {
             processState = ProcessState.PutBlock;
-            ruleSystem = new Main.RuleSystem.RuleSystem();
+            ruleSystem = new RuleSystem();
         }
 
         private void PutBlock()

--- a/Assets/Scripts/Main/RuleSystem/PlacementDetermination.cs
+++ b/Assets/Scripts/Main/RuleSystem/PlacementDetermination.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Main.Rule
+{
+    public class PlacementDetermination : MonoBehaviour
+    {
+        private int[] GridLocation = new int[3];
+        private RuleSystem ruleSystem = default;
+        public void Initialize(int x, int y, int z, RuleSystem ruleSystem)
+        {
+            GridLocation = new int[3] { x, y, z };
+            this.ruleSystem = ruleSystem;
+        }
+
+        public void PlacementBlock(int blockId)
+        {
+            // ブロックの位置を固定？する関数を呼び出しもしくはブロック側で書く
+            ruleSystem.AddBlock(GridLocation[0], GridLocation[1], GridLocation[2], blockId);
+        }
+
+        public int[] GetGridLocation()
+        {
+            return GridLocation;
+        }
+
+    }
+}

--- a/Assets/Scripts/Main/RuleSystem/PlacementDetermination.cs.meta
+++ b/Assets/Scripts/Main/RuleSystem/PlacementDetermination.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc8b0fc852d35bb4aa9e9b76cb278618
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Main/RuleSystem/PutBlockSystem.cs
+++ b/Assets/Scripts/Main/RuleSystem/PutBlockSystem.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Main.Rule
+{
+    public class PutBlockSystem
+    {
+        [SerializeField] private RuleSystem ruleSystem = default;
+        [SerializeField] private GameObject PlacementDeterminationPrefab = default;
+        private int[,] TopBlock = new int[4, 4];
+
+        public PutBlockSystem(RuleSystem ruleSystem)
+        {
+            this.ruleSystem = ruleSystem;
+        }
+
+        public void ReloardlacementDetermination()
+        {
+            // 一度全てのPlacementDeterminationを削除
+            GameObject[] objs = GameObject.FindGameObjectsWithTag("PlacementDetermination");
+            foreach (var obj in objs)
+            {
+                GameObject.Destroy(obj);
+            }
+            TopBlock = ruleSystem.CheckTopBlock();
+            // Gridの座標でそれぞれのブロックの上にブロックを設置するためのオブジェクトを生成
+            for (int i = 0; i < 4; i++)
+            {
+                for (int j = 0; j < 4; j++)
+                {
+                    if (TopBlock[i, j] < 10)
+                    {
+                        GameObject obj = GameObject.Instantiate(PlacementDeterminationPrefab, new Vector3(i, j, TopBlock[i, j]), Quaternion.identity);
+                        var placementDetermination = obj.GetComponent<PlacementDetermination>();
+                        if (placementDetermination != null)
+                        {
+                            placementDetermination.Initialize(i, j, TopBlock[i, j] + 1, ruleSystem);
+                        }
+                        // 座標は要検証
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/Assets/Scripts/Main/RuleSystem/PutBlockSystem.cs.meta
+++ b/Assets/Scripts/Main/RuleSystem/PutBlockSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c46618986751b0749bd46e3021505de0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Main/RuleSystem/RuleSystem.cs
+++ b/Assets/Scripts/Main/RuleSystem/RuleSystem.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Main.RuleSystem
+namespace Main.Rule
 {
     public class RuleSystem
     {
@@ -11,9 +11,11 @@ namespace Main.RuleSystem
         public (int blockId, bool IsCheck)[ , , ] State;
         private List<(int x,int y, int z)> DeleteBlockGroupeList = new List<(int x,int y, int z)>();
         private List<(int x,int y, int z)> BlockGroupeList = new List<(int x,int y, int z)>();
+        private PutBlockSystem putBlockSystem = default;
 
         public RuleSystem()
         {
+            putBlockSystem = new PutBlockSystem(this);
             State = new (int blockId, bool IsCheck)[ GridSize, GridSize, GridHeight ];
             for (int i = 0; i < GridSize; i++)
             {
@@ -45,6 +47,8 @@ namespace Main.RuleSystem
                     }
                 }
             }
+
+
         }
 
         private void ResetCheck()
@@ -70,7 +74,7 @@ namespace Main.RuleSystem
                 return;
             }
             BlockGroupeList.Clear();
-            checkBlock(x, y, z, State[ x, y, z ].blockId);
+            CheckBlock(x, y, z, State[ x, y, z ].blockId);
             if (BlockGroupeList.Count >= 4)
             {
                 foreach (var block in BlockGroupeList)
@@ -81,7 +85,7 @@ namespace Main.RuleSystem
 
         }
 
-        private void checkBlock(int x, int y, int z, int blockId)
+        private void CheckBlock(int x, int y, int z, int blockId)
         {
             if (x < 0 || x >= GridSize || y < 0 || y >= GridSize || z < 0 || z >= GridHeight)
             {
@@ -93,12 +97,44 @@ namespace Main.RuleSystem
             }
             BlockGroupeList.Add((x, y, z));
             State[ x, y, z ] = (State[ x, y, z ].blockId, true);
-            checkBlock(x + 1, y, z, blockId);
-            checkBlock(x - 1, y, z, blockId);
-            checkBlock(x, y + 1, z, blockId);
-            checkBlock(x, y - 1, z, blockId);
-            checkBlock(x, y, z + 1, blockId);
-            checkBlock(x, y, z - 1, blockId);
+            CheckBlock(x + 1, y, z, blockId);
+            CheckBlock(x - 1, y, z, blockId);
+            CheckBlock(x, y + 1, z, blockId);
+            CheckBlock(x, y - 1, z, blockId);
+            CheckBlock(x, y, z + 1, blockId);
+            CheckBlock(x, y, z - 1, blockId);
+        }
+
+        public void AddBlock(int x, int y, int z, int blockId)
+        {
+            State[ x, y, z ] = (blockId, false);
+            putBlockSystem.ReloardlacementDetermination();
+        }
+
+        public void RemoveBlock(int x, int y, int z)
+        {
+            State[ x, y, z ] = (0, false);
+            putBlockSystem.ReloardlacementDetermination();
+        }
+
+        public int[,] CheckTopBlock()
+        {
+            int[,] TopBlock = new int[4, 4];
+            for (int i = 0; i < GridSize; i++)
+            {
+                for (int j = 0; j < GridSize; j++)
+                {
+                    for (int k = 0; k < GridHeight; k++)
+                    {
+                        if (State[ i, j, k ].blockId != 0)
+                        {
+                            TopBlock[ i, j ] = k;
+                            break;
+                        }
+                    }
+                }
+            }
+            return TopBlock;
         }
 
         // 終了判定

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.unity.2d.tilemap": "1.0.0",
     "com.unity.collab-proxy": "2.5.2",
     "com.unity.feature.development": "1.0.1",
     "com.unity.render-pipelines.universal": "14.0.11",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,14 @@
 {
   "dependencies": {
+    "com.unity.2d.tilemap": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.tilemap": "1.0.0",
+        "com.unity.modules.uielements": "1.0.0"
+      }
+    },
     "com.unity.burst": {
       "version": "1.8.16",
       "depth": 1,


### PR DESCRIPTION
管理している場の状態から、設置用の判定を出し入れする。
設置用の判定と生成したブロックが衝突したときにブロックを管理している場に登録＆きれいに見えるように再配置 座標はタイルマップで置きなおすようにしたいが未検証
それ専用に関数用意したほうがいいかも